### PR TITLE
Added support for env variables in configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,11 @@
 								"type": "boolean",
 								"description": "Start the debugger with Bundler",
 								"default": false
+							},
+							"env": {
+								"type": "object",
+								"description": "Environment variables passed to the program",
+								"default": {}
 							}
 						}
 					}

--- a/src/rubyDebug.ts
+++ b/src/rubyDebug.ts
@@ -23,6 +23,8 @@ export class RubyDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 				reject(err);
 			});
 
+			Object.assign(process.env, session.configuration.env);
+
 			if (session.configuration.request === 'attach') {
 				let host = session.configuration.host || '127.0.0.1';
 				let port = session.configuration.port || 1234;


### PR DESCRIPTION
Should be a pretty simple fix. I verified this in a build I have that requires the env variables to work and it seemed pretty OK. Did have some issues with the packages initially though so I did do an npm update.